### PR TITLE
Fix Cargo field "RiotVersion" which renamed on-wiki

### DIFF
--- a/mwrogue/esports_client.py
+++ b/mwrogue/esports_client.py
@@ -176,7 +176,7 @@ class EsportsClient(FandomClient):
         result = self.cargo_client.query(
             tables=["MatchScheduleGame=MSG", "PostgameJsonMetadata=PJM"],
             join_on='MSG.RiotPlatformGameId=PJM.RiotPlatformGameId',
-            fields=['PJM.Version=Version', 'PJM.RiotPlatformGameId=RPGId'],
+            fields=['PJM.RiotVersion=Version', 'PJM.RiotPlatformGameId=RPGId'],
             where=f"MSG.GameId=\"{game_id}\"",
         )
         if not result:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mwrogue",
-    version="0.1.2",
+    version="0.1.3",
     author="RheingoldRiver",
     author_email="river.esports@gmail.com",
     description="Client for accessing Fandom/Gamepedia Esports Wikis",

--- a/test.py
+++ b/test.py
@@ -46,3 +46,6 @@ assert site.cache.get_disambiguated_player_from_event(
 
 # check tournaments to script
 assert "Music X Esports: Hyperplay 2018" in site.tournaments_to_skip('mhtowinners')
+
+# Check game data and timeline from game id result (Should be tuple of 2 elements => (data, timeline))
+assert len(site.get_data_and_timeline_from_gameid("LEC/2022 Season/Spring Season_Week 8_15_1")) == 2


### PR DESCRIPTION
It seems that the Riot API version field name changed on the leaguepedia `PostgameJsonMetadata` table from `Version` to `RiotVersion` which broke the query inside the `get_data_and_timeline_from_gameid` method

I also added a test for this specific method