### PR TITLE
Use self.wiki when initializing FandomClient

### DIFF
--- a/mwrogue/esports_client.py
+++ b/mwrogue/esports_client.py
@@ -51,7 +51,7 @@ class EsportsClient(FandomClient):
         """
         self.wiki = self.get_wiki(wiki)
 
-        super().__init__(wiki, credentials=credentials, lang=lang, client=client, **kwargs)
+        super().__init__(self.wiki, credentials=credentials, lang=lang, client=client, **kwargs)
         if cache:
             self.cache = cache
         else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mwrogue",
-    version="0.1.5",
+    version="0.1.6",
     author="RheingoldRiver",
     author_email="river.esports@gmail.com",
     description="Client for accessing Fandom/Gamepedia Esports Wikis",


### PR DESCRIPTION
if we use `wiki` it will use the incorrect url for all sites except lol and tft (i think)