### PR TITLE
Add support for fetching Teamnames from Cargo in lookup_cache

### DIFF
--- a/mwrogue/errors.py
+++ b/mwrogue/errors.py
@@ -15,7 +15,7 @@ class EsportsCacheKeyError(KeyError):
         )
 
 
-class EsportsCacheTeamnameKeyError(KeyError):
+class EsportsCacheCargoTeamnameKeyError(KeyError):
     def __init__(self, value, prop, value_table):
         self.value = value
         self.prop = prop

--- a/mwrogue/errors.py
+++ b/mwrogue/errors.py
@@ -15,6 +15,21 @@ class EsportsCacheKeyError(KeyError):
         )
 
 
+class EsportsCacheTeamnameKeyError(KeyError):
+    def __init__(self, value, prop, value_table):
+        self.value = value
+        self.prop = prop
+        self.value_table = value_table
+        self.allowed_keys = value_table.keys()
+
+    def __str__(self):
+        return "Invalid prop of {} requested for {}. Allowed {}".format(
+            self.prop,
+            self.value,
+            ', '.join(self.allowed_keys)
+        )
+
+
 class CantFindMatchHistory(KeyError):
     def __str__(self):
         return "Cannot find any valid tournament for provided match history. It may be missing from the MatchSchedule data, or there may be an issue with the parser."

--- a/mwrogue/lookup_cache.py
+++ b/mwrogue/lookup_cache.py
@@ -4,7 +4,7 @@ import re
 from unidecode import unidecode
 
 from mwcleric.clients.cargo_client import CargoClient
-from .errors import EsportsCacheKeyError, EsportsCacheTeamnameKeyError, InvalidEventError
+from .errors import EsportsCacheKeyError, EsportsCacheCargoTeamnameKeyError, InvalidEventError
 from mwcleric.clients.site import Site
 
 
@@ -104,7 +104,7 @@ class EsportsLookupCache(object):
             return None
         value_table = self.cargo_teamnames_cache[key]
         if prop not in value_table:
-            raise EsportsCacheTeamnameKeyError(key, prop, value_table)
+            raise EsportsCacheCargoTeamnameKeyError(key, prop, value_table)
         return value_table[prop]
 
     def _populate_cargo_teamnames(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mwrogue",
-    version="0.1.6",
+    version="0.1.7",
     author="RheingoldRiver",
     author_email="river.esports@gmail.com",
     description="Client for accessing Fandom/Gamepedia Esports Wikis",

--- a/test.py
+++ b/test.py
@@ -21,8 +21,8 @@ assert site.cache.get_disambiguated_player_from_event(
     'El_Nexo/2020_Season/Split_1_Playoffs', 'Movistar Riders Academy', 'Marky'
 ) == 'Marky (Pedro José Serrano)'
 
-# check fallback to Teams.Short
-assert site.cache.get_team_from_event_tricode('GUL 2020 Closing Playoffs', 'MK') == 'Mad Kings'
+# check fallback to tournament rosters short
+assert site.cache.get_team_from_event_tricode('2014 Season World Championship', 'NWS') == 'NaJin White Shield'
 
 assert site.cache.get_team_from_event_tricode('Worlds 2019 Main Event', 'SKT') == 'SK Telecom T1'
 
@@ -49,3 +49,12 @@ assert "Music X Esports: Hyperplay 2018" in site.tournaments_to_skip('mhtowinner
 
 # Check game data and timeline from game id result (Should be tuple of 2 elements => (data, timeline))
 assert len(site.get_data_and_timeline_from_gameid("LEC/2022 Season/Spring Season_Week 8_15_1")) == 2
+
+# Check cargo teamnames
+assert site.cache.get_cargo_teamname("isg", "Link") == "Isurus"
+
+# Check if teamnames inputs is actually a list and we split correctly
+assert isinstance(site.cache.get_cargo_teamname("fnc", "Inputs"), list)
+
+# Check if cargo teamnames cache was populated
+assert site.cache.cargo_teamnames_cache


### PR DESCRIPTION
I added two functions, `_populate_cargo_teamnames` and `get_cargo_teamname`. The first one queries Cargo to fetch all rows stored in the `Teamnames` table, and caches the result. The second one is the equivalent to `get`, but uses teamnames data from cargo. Its practically a copy of `get` but I didn't know how to handle raising different exceptions with different parameters.

I also created a new exception so we can raise it if a length or prop wasn't found in the value_table, added a couple tests, and modified some functions to use the new method to fetch teamnames stuff. (and bumped the version)